### PR TITLE
Fix predict.glm usage

### DIFF
--- a/modeling.r
+++ b/modeling.r
@@ -716,9 +716,33 @@ coef(models$final$lasso)
 summary(models$final$vanilla) 
 
 # Predictions  -------------------------------------------------
-pred$train$boosted_glm$vanilla <- sapply(as.numeric(predict.glm(models$final$vanilla, newdat=boosting_df$train_factors_final, type="response", newoffset=boosting_df$train_factors_final$dur)) , function(x) min(x,2))    
-pred$cal$boosted_glm$vanilla <- sapply(as.numeric(predict.glm(models$final$vanilla, newdat=boosting_df$cal_factors_final, type="response"), newoffset=boosting_df$cal_factors_final$dur), function(x) min(x,2))  
-pred$test$boosted_glm$vanilla <- sapply(as.numeric(predict.glm(models$final$vanilla, newdat=boosting_df$test_factors_final, type="response") , newoffset=boosting_df$test_factors_final$dur ) , function(x) min(x,2))
+pred$train$boosted_glm$vanilla <- sapply(
+  as.numeric(predict.glm(
+    models$final$vanilla,
+    newdata = boosting_df$train_factors_final,
+    type = "response",
+    offset = log(boosting_df$train_factors_final$dur)
+  )),
+  function(x) min(x, 2)
+)
+pred$cal$boosted_glm$vanilla <- sapply(
+  as.numeric(predict.glm(
+    models$final$vanilla,
+    newdata = boosting_df$cal_factors_final,
+    type = "response",
+    offset = log(boosting_df$cal_factors_final$dur)
+  )),
+  function(x) min(x, 2)
+)
+pred$test$boosted_glm$vanilla <- sapply(
+  as.numeric(predict.glm(
+    models$final$vanilla,
+    newdata = boosting_df$test_factors_final,
+    type = "response",
+    offset = log(boosting_df$test_factors_final$dur)
+  )),
+  function(x) min(x, 2)
+)
  
 pred$train$boosted_glm$lasso <- sapply(as.numeric(predict(models$final$lasso,  newx = model.matrix(models$final$functional_form_lasso , boosting_df$train_factors_final ), type = "response",  s = best_lambda, newoffset = log(boosting_df$train_factors_final$dur) )), function(x) min(x,2))  
 pred$cal$boosted_glm$lasso <- sapply(as.numeric(predict(models$final$lasso, newx = model.matrix(models$final$functional_form_lasso , boosting_df$cal_factors_final ), type = "response", s = best_lambda, newoffset = log(boosting_df$cal_factors$dur))), function(x) min(x,2))  

--- a/summary.r
+++ b/summary.r
@@ -120,10 +120,19 @@ for (data in c( "norauto","beMTPL", "auspriv","freMTPL")){ #  "norauto","beMTPL"
       
       final_data_temp[fact] <- predict(all_trees[[fact]],newdata = pdp_data_temp)
       
-      pdp_values_temp[[fact]][i,"final_model_vanilla"] <- mean(sapply(as.numeric(predict.glm(models$final$vanilla,
-                                                                                             newdat=final_data_temp, 
-                                                                                             type="response", 
-                                                                                             newoffset=final_data_temp$dur)) , function(x) min(x,2)))
+      pdp_values_temp[[fact]][i, "final_model_vanilla"] <- mean(
+        sapply(
+          as.numeric(
+            predict.glm(
+              models$final$vanilla,
+              newdata = final_data_temp,
+              type = "response",
+              offset = log(final_data_temp$dur)
+            )
+          ),
+          function(x) min(x, 2)
+        )
+      )
     
       pdp_values_temp[[fact]][i,"final_model_lasso"] <- mean(sapply(as.numeric(predict(models$final$lasso,  
                                                                                        newx = model.matrix(models$final$functional_form_lasso , 


### PR DESCRIPTION
## Summary
- correct argument names for `predict.glm` when generating predictions
- use `offset = log(dur)` for GLM predictions

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409e9b18a4832e87bc3c713174ea3e